### PR TITLE
Support for de_DE and altered test structure to allow all locale tests to run

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -11,7 +11,8 @@ component {
 
     function onLoad() {
         var resourceService = wirebox.getInstance( "ResourceService@cbi18n" );
-        resourceService.loadBundle( "#moduleMapping#/resources/i18n/coda" );
+        resourceService.loadBundle( "#moduleMapping#/resources/i18n/coda","en_US" );
+        resourceService.loadBundle( "#moduleMapping#/resources/i18n/coda","de_DE" );
     }
 
 }

--- a/resources/i18n/coda_de_DE.json
+++ b/resources/i18n/coda_de_DE.json
@@ -1,0 +1,18 @@
+{
+    "lessThanXSeconds": "weniger als {1} Sekunden",
+    "halfAMinute": "eine halbe Minute",
+    "lessThanAMinute": "weniger als 1 Minute",
+    "oneMinute": "1 Minute",
+    "xMinutes": "{1} Minuten",
+    "aboutAnHour": "circa 1 Stunde",
+    "aboutXHours": "circa {1} Stunden",
+    "aDay": "1 Tag",
+    "xDays": "{1} Tage",
+    "aboutAMonth": "circa 1 Monat",
+    "xMonths": "{1} Monate",
+    "aboutAYear": "circa 1 Jahr",
+    "aboutXYears": "circa {1} Jahre",
+    "overAYear": "über 1 Jahr",
+    "overXYears": "über {1} Jahre",
+    "almostXYears": "fast {1} Jahre"
+}

--- a/tests/resources/AbstractFormatDistanceSpec.cfc
+++ b/tests/resources/AbstractFormatDistanceSpec.cfc
@@ -27,140 +27,140 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 it( "less than 5s", function() {
                     var date = createDateTime( 2021, 1, 1, 12, 0, 3 );
                     var baseDate = createDateTime( 2021, 1, 1, 12, 0, 0 );
-                    expect( coda.formatDistance( date, baseDate, INCLUDE_SECONDS, getTestLocale() ) ).toBe( lessThanFiveSeconds() );
+                    expect( coda.formatDistance( date, baseDate, INCLUDE_SECONDS, getTestLocale() ) ).toBeWithCase( lessThanFiveSeconds() );
                 } );
 
                 it( "less than 10s", function() {
                     var date = createDateTime( 2021, 1, 1, 12, 0, 8 );
                     var baseDate = createDateTime( 2021, 1, 1, 12, 0, 0 );
-                    expect( coda.formatDistance( date, baseDate, INCLUDE_SECONDS, getTestLocale() ) ).toBe( lessThanTenSeconds() );
+                    expect( coda.formatDistance( date, baseDate, INCLUDE_SECONDS, getTestLocale() ) ).toBeWithCase( lessThanTenSeconds() );
                 } );
 
                 it( "less than 20s", function() {
                     var date = createDateTime( 2021, 1, 1, 12, 0, 15 );
                     var baseDate = createDateTime( 2021, 1, 1, 12, 0, 0 );
-                    expect( coda.formatDistance( date, baseDate, INCLUDE_SECONDS, getTestLocale() ) ).toBe( lessThanTwentySeconds() );
+                    expect( coda.formatDistance( date, baseDate, INCLUDE_SECONDS, getTestLocale() ) ).toBeWithCase( lessThanTwentySeconds() );
                 } );
 
                 it( "less than 40s", function() {
                     var date = createDateTime( 2021, 1, 1, 12, 0, 39 );
                     var baseDate = createDateTime( 2021, 1, 1, 12, 0, 0 );
-                    expect( coda.formatDistance( date, baseDate, INCLUDE_SECONDS, getTestLocale() ) ).toBe( halfAMinute() );
+                    expect( coda.formatDistance( date, baseDate, INCLUDE_SECONDS, getTestLocale() ) ).toBeWithCase( halfAMinute() );
                 } );
 
                 it( "less than 60s", function() {
                     var date = createDateTime( 2021, 1, 1, 12, 0, 55 );
                     var baseDate = createDateTime( 2021, 1, 1, 12, 0, 0 );
-                    expect( coda.formatDistance( date, baseDate, INCLUDE_SECONDS, getTestLocale() ) ).toBe( lessThanAMinute() );
+                    expect( coda.formatDistance( date, baseDate, INCLUDE_SECONDS, getTestLocale() ) ).toBeWithCase( lessThanAMinute() );
                 } );
             } );
 
             it( "0 to 59s", function() {
                 var date = createDateTime( 2021, 1, 1, 12, 0, 15 );
                 var baseDate = createDateTime( 2021, 1, 1, 12, 0, 0 );
-                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( lessThanAMinute() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBeWithCase( lessThanAMinute() );
             } );
 
             it( "1m to 2m", function() {
                 var date = createDateTime( 2021, 1, 1, 12, 1, 05 );
                 var baseDate = createDateTime( 2021, 1, 1, 12, 0, 0 );
-                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( oneMinute() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBeWithCase( oneMinute() );
             } );
 
             it( "2m to 45m", function() {
                 var date = createDateTime( 2021, 1, 1, 12, 5, 0 );
                 var baseDate = createDateTime( 2021, 1, 1, 12, 0, 0 );
-                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( fiveMinutes() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBeWithCase( fiveMinutes() );
 
                 date = createDateTime( 2021, 1, 1, 12, 21, 0 );
                 baseDate = createDateTime( 2021, 1, 1, 12, 0, 0 );
-                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( twentyOneMinutes() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBeWithCase( twentyOneMinutes() );
             } );
 
             it( "45m to 1.5h", function() {
                 var date = createDateTime( 2021, 1, 1, 12, 48, 0 );
                 var baseDate = createDateTime( 2021, 1, 1, 12, 0, 0 );
-                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( aboutAnHour() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBeWithCase( aboutAnHour() );
 
                 date = createDateTime( 2021, 1, 1, 13, 29, 0 );
                 baseDate = createDateTime( 2021, 1, 1, 12, 0, 0 );
-                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( aboutAnHour() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBeWithCase( aboutAnHour() );
             } );
 
             it( "1.5h to 24h", function() {
                 var date = createDateTime( 2021, 1, 1, 15, 29, 0 );
                 var baseDate = createDateTime( 2021, 1, 1, 12, 0, 0 );
-                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( aboutThreeHours() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBeWithCase( aboutThreeHours() );
 
                 date = createDateTime( 2021, 1, 1, 15, 45, 0 );
                 baseDate = createDateTime( 2021, 1, 1, 12, 0, 0 );
-                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( aboutFourHours() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBeWithCase( aboutFourHours() );
             } );
 
             it( "1d to 1.75d", function() {
                 var date = createDateTime( 2021, 1, 2, 15, 0, 0 );
                 var baseDate = createDateTime( 2021, 1, 1, 12, 0, 0 );
-                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( aDay() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBeWithCase( aDay() );
 
                 date = createDateTime( 2021, 1, 2, 17, 0, 0 );
                 baseDate = createDateTime( 2021, 1, 1, 0, 0, 0 );
-                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( aDay() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBeWithCase( aDay() );
             } );
 
             it( "1.75d to 30d", function() {
                 var date = createDateTime( 2021, 1, 2, 18, 30, 0 );
                 var baseDate = createDateTime( 2021, 1, 1, 0, 0, 0 );
-                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( twoDays() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBeWithCase( twoDays() );
 
                 date = createDateTime( 2021, 1, 21, 2, 30, 0 );
                 baseDate = createDateTime( 2021, 1, 1, 0, 0, 0 );
-                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( twentyDays() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBeWithCase( twentyDays() );
             } );
 
             it( "1mos to 2mos", function() {
                 var date = createDateTime( 2021, 2, 1, 2, 30, 0 );
                 var baseDate = createDateTime( 2021, 1, 1, 0, 0, 0 );
-                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( aboutAMonth() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBeWithCase( aboutAMonth() );
             } );
 
             it( "2mos to 12mos", function() {
                 var date = createDateTime( 2021, 6, 1, 2, 30, 0 );
                 var baseDate = createDateTime( 2021, 1, 1, 0, 0, 0 );
-                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( fiveMonths() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBeWithCase( fiveMonths() );
 
                 date = createDateTime( 2021, 12, 1, 2, 30, 0 );
                 baseDate = createDateTime( 2021, 1, 1, 0, 0, 0 );
-                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( elevenMonths() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBeWithCase( elevenMonths() );
             } );
 
             it( "N years to N years 3 months", function() {
                 var date = createDateTime( 2022, 1, 2, 0, 0, 0 );
                 var baseDate = createDateTime( 2021, 1, 1, 0, 0, 0 );
-                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( aboutAYear() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBeWithCase( aboutAYear() );
 
                 date = createDateTime( 2023, 1, 2, 0, 0, 0 );
                 baseDate = createDateTime( 2021, 1, 1, 0, 0, 0 );
-                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( aboutTwoYears() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBeWithCase( aboutTwoYears() );
             } );
 
             it( "N years 3 months to N years 9 months", function() {
                 var date = createDateTime( 2022, 5, 1, 0, 0, 0 );
                 var baseDate = createDateTime( 2021, 1, 1, 0, 0, 0 );
-                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( overAYear() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBeWithCase( overAYear() );
 
                 date = createDateTime( 2023, 9, 1, 0, 0, 0 );
                 baseDate = createDateTime( 2021, 1, 1, 0, 0, 0 );
-                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( overTwoYears() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBeWithCase( overTwoYears() );
             } );
 
             it( "N years 9 months to N years 12 months", function() {
                 var date = createDateTime( 2022, 11, 1, 0, 0, 0 );
                 var baseDate = createDateTime( 2021, 1, 1, 0, 0, 0 );
-                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( almostTwoYears() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBeWithCase( almostTwoYears() );
 
                 date = createDateTime( 2023, 12, 1, 0, 0, 0 );
                 baseDate = createDateTime( 2021, 1, 1, 0, 0, 0 );
-                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( almostThreeYears() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBeWithCase( almostThreeYears() );
             } );
         } );
     }

--- a/tests/resources/AbstractFormatDistanceSpec.cfc
+++ b/tests/resources/AbstractFormatDistanceSpec.cfc
@@ -27,148 +27,152 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 it( "less than 5s", function() {
                     var date = createDateTime( 2021, 1, 1, 12, 0, 3 );
                     var baseDate = createDateTime( 2021, 1, 1, 12, 0, 0 );
-                    expect( coda.formatDistance( date, baseDate, INCLUDE_SECONDS ) ).toBe( lessThanFiveSeconds() );
+                    expect( coda.formatDistance( date, baseDate, INCLUDE_SECONDS, getTestLocale() ) ).toBe( lessThanFiveSeconds() );
                 } );
 
                 it( "less than 10s", function() {
                     var date = createDateTime( 2021, 1, 1, 12, 0, 8 );
                     var baseDate = createDateTime( 2021, 1, 1, 12, 0, 0 );
-                    expect( coda.formatDistance( date, baseDate, INCLUDE_SECONDS ) ).toBe( lessThanTenSeconds() );
+                    expect( coda.formatDistance( date, baseDate, INCLUDE_SECONDS, getTestLocale() ) ).toBe( lessThanTenSeconds() );
                 } );
 
                 it( "less than 20s", function() {
                     var date = createDateTime( 2021, 1, 1, 12, 0, 15 );
                     var baseDate = createDateTime( 2021, 1, 1, 12, 0, 0 );
-                    expect( coda.formatDistance( date, baseDate, INCLUDE_SECONDS ) ).toBe( lessThanTwentySeconds() );
+                    expect( coda.formatDistance( date, baseDate, INCLUDE_SECONDS, getTestLocale() ) ).toBe( lessThanTwentySeconds() );
                 } );
 
                 it( "less than 40s", function() {
                     var date = createDateTime( 2021, 1, 1, 12, 0, 39 );
                     var baseDate = createDateTime( 2021, 1, 1, 12, 0, 0 );
-                    expect( coda.formatDistance( date, baseDate, INCLUDE_SECONDS ) ).toBe( halfAMinute() );
+                    expect( coda.formatDistance( date, baseDate, INCLUDE_SECONDS, getTestLocale() ) ).toBe( halfAMinute() );
                 } );
 
                 it( "less than 60s", function() {
                     var date = createDateTime( 2021, 1, 1, 12, 0, 55 );
                     var baseDate = createDateTime( 2021, 1, 1, 12, 0, 0 );
-                    expect( coda.formatDistance( date, baseDate, INCLUDE_SECONDS ) ).toBe( lessThanAMinute() );
+                    expect( coda.formatDistance( date, baseDate, INCLUDE_SECONDS, getTestLocale() ) ).toBe( lessThanAMinute() );
                 } );
             } );
 
             it( "0 to 59s", function() {
                 var date = createDateTime( 2021, 1, 1, 12, 0, 15 );
                 var baseDate = createDateTime( 2021, 1, 1, 12, 0, 0 );
-                expect( coda.formatDistance( date, baseDate ) ).toBe( lessThanAMinute() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( lessThanAMinute() );
             } );
 
             it( "1m to 2m", function() {
                 var date = createDateTime( 2021, 1, 1, 12, 1, 05 );
                 var baseDate = createDateTime( 2021, 1, 1, 12, 0, 0 );
-                expect( coda.formatDistance( date, baseDate ) ).toBe( oneMinute() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( oneMinute() );
             } );
 
             it( "2m to 45m", function() {
                 var date = createDateTime( 2021, 1, 1, 12, 5, 0 );
                 var baseDate = createDateTime( 2021, 1, 1, 12, 0, 0 );
-                expect( coda.formatDistance( date, baseDate ) ).toBe( fiveMinutes() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( fiveMinutes() );
 
                 date = createDateTime( 2021, 1, 1, 12, 21, 0 );
                 baseDate = createDateTime( 2021, 1, 1, 12, 0, 0 );
-                expect( coda.formatDistance( date, baseDate ) ).toBe( twentyOneMinutes() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( twentyOneMinutes() );
             } );
 
             it( "45m to 1.5h", function() {
                 var date = createDateTime( 2021, 1, 1, 12, 48, 0 );
                 var baseDate = createDateTime( 2021, 1, 1, 12, 0, 0 );
-                expect( coda.formatDistance( date, baseDate ) ).toBe( aboutAnHour() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( aboutAnHour() );
 
                 date = createDateTime( 2021, 1, 1, 13, 29, 0 );
                 baseDate = createDateTime( 2021, 1, 1, 12, 0, 0 );
-                expect( coda.formatDistance( date, baseDate ) ).toBe( aboutAnHour() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( aboutAnHour() );
             } );
 
             it( "1.5h to 24h", function() {
                 var date = createDateTime( 2021, 1, 1, 15, 29, 0 );
                 var baseDate = createDateTime( 2021, 1, 1, 12, 0, 0 );
-                expect( coda.formatDistance( date, baseDate ) ).toBe( aboutThreeHours() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( aboutThreeHours() );
 
                 date = createDateTime( 2021, 1, 1, 15, 45, 0 );
                 baseDate = createDateTime( 2021, 1, 1, 12, 0, 0 );
-                expect( coda.formatDistance( date, baseDate ) ).toBe( aboutFourHours() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( aboutFourHours() );
             } );
 
             it( "1d to 1.75d", function() {
                 var date = createDateTime( 2021, 1, 2, 15, 0, 0 );
                 var baseDate = createDateTime( 2021, 1, 1, 12, 0, 0 );
-                expect( coda.formatDistance( date, baseDate ) ).toBe( aDay() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( aDay() );
 
                 date = createDateTime( 2021, 1, 2, 17, 0, 0 );
                 baseDate = createDateTime( 2021, 1, 1, 0, 0, 0 );
-                expect( coda.formatDistance( date, baseDate ) ).toBe( aDay() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( aDay() );
             } );
 
             it( "1.75d to 30d", function() {
                 var date = createDateTime( 2021, 1, 2, 18, 30, 0 );
                 var baseDate = createDateTime( 2021, 1, 1, 0, 0, 0 );
-                expect( coda.formatDistance( date, baseDate ) ).toBe( twoDays() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( twoDays() );
 
                 date = createDateTime( 2021, 1, 21, 2, 30, 0 );
                 baseDate = createDateTime( 2021, 1, 1, 0, 0, 0 );
-                expect( coda.formatDistance( date, baseDate ) ).toBe( twentyDays() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( twentyDays() );
             } );
 
             it( "1mos to 2mos", function() {
                 var date = createDateTime( 2021, 2, 1, 2, 30, 0 );
                 var baseDate = createDateTime( 2021, 1, 1, 0, 0, 0 );
-                expect( coda.formatDistance( date, baseDate ) ).toBe( aboutAMonth() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( aboutAMonth() );
             } );
 
             it( "2mos to 12mos", function() {
                 var date = createDateTime( 2021, 6, 1, 2, 30, 0 );
                 var baseDate = createDateTime( 2021, 1, 1, 0, 0, 0 );
-                expect( coda.formatDistance( date, baseDate ) ).toBe( fiveMonths() );
-                
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( fiveMonths() );
+
                 date = createDateTime( 2021, 12, 1, 2, 30, 0 );
                 baseDate = createDateTime( 2021, 1, 1, 0, 0, 0 );
-                expect( coda.formatDistance( date, baseDate ) ).toBe( elevenMonths() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( elevenMonths() );
             } );
 
             it( "N years to N years 3 months", function() {
                 var date = createDateTime( 2022, 1, 2, 0, 0, 0 );
                 var baseDate = createDateTime( 2021, 1, 1, 0, 0, 0 );
-                expect( coda.formatDistance( date, baseDate ) ).toBe( aboutAYear() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( aboutAYear() );
 
                 date = createDateTime( 2023, 1, 2, 0, 0, 0 );
                 baseDate = createDateTime( 2021, 1, 1, 0, 0, 0 );
-                expect( coda.formatDistance( date, baseDate ) ).toBe( aboutTwoYears() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( aboutTwoYears() );
             } );
 
             it( "N years 3 months to N years 9 months", function() {
                 var date = createDateTime( 2022, 5, 1, 0, 0, 0 );
                 var baseDate = createDateTime( 2021, 1, 1, 0, 0, 0 );
-                expect( coda.formatDistance( date, baseDate ) ).toBe( overAYear() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( overAYear() );
 
                 date = createDateTime( 2023, 9, 1, 0, 0, 0 );
                 baseDate = createDateTime( 2021, 1, 1, 0, 0, 0 );
-                expect( coda.formatDistance( date, baseDate ) ).toBe( overTwoYears() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( overTwoYears() );
             } );
 
             it( "N years 9 months to N years 12 months", function() {
                 var date = createDateTime( 2022, 11, 1, 0, 0, 0 );
                 var baseDate = createDateTime( 2021, 1, 1, 0, 0, 0 );
-                expect( coda.formatDistance( date, baseDate ) ).toBe( almostTwoYears() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( almostTwoYears() );
 
                 date = createDateTime( 2023, 12, 1, 0, 0, 0 );
                 baseDate = createDateTime( 2021, 1, 1, 0, 0, 0 );
-                expect( coda.formatDistance( date, baseDate ) ).toBe( almostThreeYears() );
+                expect( coda.formatDistance( date, baseDate, !INCLUDE_SECONDS, getTestLocale() ) ).toBe( almostThreeYears() );
             } );
         } );
+    }
+
+    function getTestLocale() {
+        throw( "method is abstract and must be implemented in a subclass" );
     }
 
     function lessThanFiveSeconds() {
         throw( "method is abstract and must be implemented in a subclass" );
     }
-    
+
     function lessThanTenSeconds() {
         throw( "method is abstract and must be implemented in a subclass" );
     }
@@ -192,7 +196,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
     function fiveMinutes() {
         throw( "method is abstract and must be implemented in a subclass" );
     }
-    
+
     function twentyOneMinutes() {
         throw( "method is abstract and must be implemented in a subclass" );
     }
@@ -204,7 +208,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
     function aboutThreeHours() {
         throw( "method is abstract and must be implemented in a subclass" );
     }
-    
+
     function aboutFourHours() {
         throw( "method is abstract and must be implemented in a subclass" );
     }

--- a/tests/specs/integration/FormatDistance_DE_DE_Spec.cfc
+++ b/tests/specs/integration/FormatDistance_DE_DE_Spec.cfc
@@ -1,0 +1,95 @@
+component extends="tests.resources.AbstractFormatDistanceSpec" {
+
+    function lessThanFiveSeconds() {
+        return "weniger als 5 Sekunden";
+    }
+
+    function lessThanTenSeconds() {
+        return "weniger als 10 Sekunden";
+    }
+
+    function lessThanTwentySeconds() {
+        return "weniger als 20 Sekunden";
+    }
+
+    function halfAMinute() {
+        return "eine halbe Minute";
+    }
+
+    function lessThanAMinute() {
+        return "weniger als 1 Minute";
+    }
+
+    function oneMinute() {
+        return "1 Minute";
+    }
+
+    function fiveMinutes() {
+        return "5 Minuten";
+    }
+
+    function twentyOneMinutes() {
+        return "21 Minuten";
+    }
+
+    function aboutAnHour() {
+        return "circa 1 Stunde";
+    }
+
+    function aboutThreeHours() {
+        return "circa 3 Stunden";
+    }
+
+    function aboutFourHours() {
+        return "circa 4 Stunden";
+    }
+
+    function aDay() {
+        return "1 Tag";
+    }
+
+    function twoDays() {
+        return "2 Tage";
+    }
+
+    function twentyDays() {
+        return "20 Tage";
+    }
+
+    function aboutAMonth() {
+        return "circa 1 Monat";
+    }
+
+    function fiveMonths() {
+        return "5 Monate";
+    }
+
+    function elevenMonths() {
+        return "11 Monate";
+    }
+
+    function aboutAYear() {
+        return "circa 1 Jahr";
+    }
+
+    function aboutTwoYears() {
+        return "circa 2 Jahre";
+    }
+
+    function overAYear() {
+        return "über 1 Jahr";
+    }
+
+    function overTwoYears() {
+        return "über 2 Jahre";
+    }
+
+    function almostTwoYears() {
+        return "fast 2 Jahre";
+    }
+
+    function almostThreeYears() {
+        return "fast 3 Jahre";
+    }
+
+}

--- a/tests/specs/integration/FormatDistance_DE_DE_Spec.cfc
+++ b/tests/specs/integration/FormatDistance_DE_DE_Spec.cfc
@@ -1,5 +1,9 @@
 component extends="tests.resources.AbstractFormatDistanceSpec" {
 
+    function getTestLocale() {
+        return "de_DE";
+    }
+
     function lessThanFiveSeconds() {
         return "weniger als 5 Sekunden";
     }

--- a/tests/specs/integration/FormatDistance_EN_US_Spec.cfc
+++ b/tests/specs/integration/FormatDistance_EN_US_Spec.cfc
@@ -1,5 +1,9 @@
 component extends="tests.resources.AbstractFormatDistanceSpec" {
 
+    function getTestLocale() {
+        return "en_US";
+    }
+
     function lessThanFiveSeconds() {
         return "less than 5 seconds";
     }


### PR DESCRIPTION
Added `de_DE`, which was easy.

But when I tried to run the tests, it would always load the `en_US` bundle, even when I explicitly requested `de_DE` in a test by hard coding it in.

The solution as PR'ed is now working, but not sure if that's how it'd be supposed to be done.

Will leave a few questions attached to snippets.